### PR TITLE
Adding of tests to check battery level validation

### DIFF
--- a/watering_app/test/models/plant_test.rb
+++ b/watering_app/test/models/plant_test.rb
@@ -15,4 +15,14 @@ class PlantTest < ActiveSupport::TestCase
     plant = Plant.new({name: "spider plant", moisture_level: 101, water_pump_status: "off", battery_level: 33 })
     assert_not plant.valid?
   end
+
+  test "fail on battery level below 0" do
+    plant = Plant.new({name: "spider plant", moisture_level: 53, water_pump_status: "off", battery_level: -55 })
+    assert_not plant.valid?
+  end
+
+  test "fail on battery level above 100" do
+    plant = Plant.new({name: "spider plant", moisture_level: 11, water_pump_status: "off", battery_level: 101 })
+    assert_not plant.valid?
+  end
 end


### PR DESCRIPTION
Creating of tests to check the validation of battery level to ensure it is not above 100 or below 0.
At present they fail successfully due to the models not containing validation for this check.